### PR TITLE
Add basic manifest.

### DIFF
--- a/manifest.webapp
+++ b/manifest.webapp
@@ -1,0 +1,23 @@
+{
+  "name": "Hiro",
+  "description": "Hiro",
+  "launch_path": "./index.html",
+  "type": "certified",
+  "role": "system",
+  "developer": {
+      "name": "Mozilla",
+      "url": "https://mozilla.org"
+  },
+  "permissions": {
+    "browser": {},
+    "embed-apps": {},
+    "systemXHR": {},
+    "settings": {
+      "access": "readwrite"
+    },
+    "geolocation": {},
+    "desktop-notification": {},
+    "audio-capture": {},
+    "video-capture": {}
+  }
+}


### PR DESCRIPTION
Basically just took the same thing that graphene is using. The permissions probably aren't correct, but we can audit those later.

This will allow us to point to the manifest as a --start-manifest argument using it from graphene hopefully.

@caseyyee - R?
